### PR TITLE
Add mappingType parameter to CollisionMesh

### DIFF
--- a/python/stlib/physics/collision/collision.py
+++ b/python/stlib/physics/collision/collision.py
@@ -15,9 +15,9 @@ def CollisionMesh(attachedTo=None,
                   rotation=[0.0,0.0,0.0],
                   translation=[0.0,0.0,0.0],
                   collisionGroup=None, mappingType='BarycentricMapping'):
-        '''
+    '''
 
-        '''
+    '''
 
     if attachedTo == None:
         Sofa.msg_error("Cannot create a CollisionMesh that is not attached to node.")

--- a/python/stlib/physics/collision/collision.py
+++ b/python/stlib/physics/collision/collision.py
@@ -14,7 +14,10 @@ def CollisionMesh(attachedTo=None,
                   name="collision",
                   rotation=[0.0,0.0,0.0],
                   translation=[0.0,0.0,0.0],
-                  collisionGroup=None):
+                  collisionGroup=None, mappingType='BarycentricMapping'):
+        '''
+
+        '''
 
     if attachedTo == None:
         Sofa.msg_error("Cannot create a CollisionMesh that is not attached to node.")
@@ -39,7 +42,9 @@ def CollisionMesh(attachedTo=None,
         collisionmodel.createObject('Line')
         collisionmodel.createObject('Triangle')
     
-    collisionmodel.createObject('BarycentricMapping')
+    if mappingType!=None:
+        collisionmodel.createObject(mappingType)
+
 
     return collisionmodel
     


### PR DESCRIPTION
Default value implemented: 'BarycentricMapping' (former value)
Otherwise the user can define the wanted mapping type, or no mapping at all (value None)