### PR TITLE
[visuals&deformable] fixed visual issue

### DIFF
--- a/python/stlib/physics/deformable/elasticmaterialobject.py
+++ b/python/stlib/physics/deformable/elasticmaterialobject.py
@@ -2,6 +2,7 @@
 import Sofa
 from splib.objectmodel import SofaPrefab, SofaObject
 from stlib.scene import Node
+from stlib.visuals import VisualModel
 
 @SofaPrefab
 class ElasticMaterialObject(SofaObject):
@@ -91,11 +92,7 @@ class ElasticMaterialObject(SofaObject):
         self.collisionmodel.createObject('BarycentricMapping')
 
     def addVisualModel(self, filename, color, rotation, translation):
-        self.visualmodel = SofaObject(self.node, "VisualModel")
-
-            ## Add to this empty node a rendering model made of triangles and loaded from an stl file.
-        self.visualmodel.model = self.visualmodel.node.createObject('OglModel', filename=filename,
-                                                                   template='ExtVec3f', color=color, rotation=rotation, translation=translation)
+        self.visualmodel = VisualModel(parent=self.node,surfaceMeshFileName=filename,color=color,rotation=rotation,translation=translation)
 
             ## Add a BarycentricMapping to deform the rendering model to follow the ones of the
             ## mechanical model.

--- a/python/stlib/visuals/__init__.py
+++ b/python/stlib/visuals/__init__.py
@@ -21,6 +21,8 @@ class VisualModel(SofaObject):
             parent
             surfaceMeshFileName
             color
+            rotation
+            translation
 
        Content:
            Node
@@ -30,7 +32,7 @@ class VisualModel(SofaObject):
                 OglModel : "model'
            }
     """
-    def __init__(self, parent, surfaceMeshFileName, color=[1.0,1.0,1.0]):
+    def __init__(self, parent, surfaceMeshFileName, color=[1.0,1.0,1.0], rotation=[0.0,0.0,0.0], translation=[0.0,0.0,0.0]):
         self.node  = Node(parent, "VisualModel")
 
         if surfaceMeshFileName.endswith(".stl"):
@@ -41,9 +43,12 @@ class VisualModel(SofaObject):
             self.loader = self.node.createObject('MeshObjLoader',
                                                  name="loader",
                                                  filename=surfaceMeshFileName)
+        else:
+            print("Extension not handled in STLIB/python/stlib/visuals for file: "+str(surfaceMeshFileName))
 
         self.model = self.node.createObject('OglModel',
                                         name="model",
-                                        position='@loader.position',
-                                        triangles='@loader.triangles',
+                                        src="@loader",
+                                        rotation=rotation,
+                                        translation=translation,
                                         color=color, updateNormals=False)


### PR DESCRIPTION
- Added warning message in case of unsupported file extension in stlib/visuals
- Refactoring and fix: In stlib/physics/deformable, use template visuals.