### PR TITLE
[stlib.physics] Rigidification, add framePosition param

### DIFF
--- a/python/stlib/physics/collision/collision.py
+++ b/python/stlib/physics/collision/collision.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
 import Sofa
 
+
 def loaderFor(name):
     if name.endswith(".obj"):
         return "MeshObjLoader"
@@ -8,24 +9,26 @@ def loaderFor(name):
         return "MeshSTLLoader"
     elif name.endswith(".vtk"):
         return "MeshVTKLoader"
-   
-def CollisionMesh(attachedTo=None, 
+
+
+def CollisionMesh(attachedTo=None,
                   surfaceMeshFileName=None,
                   name="collision",
-                  rotation=[0.0,0.0,0.0],
-                  translation=[0.0,0.0,0.0],
-                  collisionGroup=None, mappingType='BarycentricMapping'):
+                  rotation=[0.0, 0.0, 0.0],
+                  translation=[0.0, 0.0, 0.0],
+                  collisionGroup=None,
+                  mappingType='BarycentricMapping'):
     '''
 
     '''
 
-    if attachedTo == None:
+    if attachedTo is None:
         Sofa.msg_error("Cannot create a CollisionMesh that is not attached to node.")
         return None
 
     collisionmodel = attachedTo.createChild(name)
 
-    if surfaceMeshFileName == None:
+    if surfaceMeshFileName is None:
         Sofa.msg_error(collisionmodel, "Unable to create a CollisionMesh without a surface mesh")
         return None
 
@@ -37,17 +40,16 @@ def CollisionMesh(attachedTo=None,
         collisionmodel.createObject('Point', group=collisionGroup)
         collisionmodel.createObject('Line', group=collisionGroup)
         collisionmodel.createObject('Triangle', group=collisionGroup)
-    else:    
+    else:
         collisionmodel.createObject('Point')
         collisionmodel.createObject('Line')
         collisionmodel.createObject('Triangle')
-    
-    if mappingType!=None:
+
+    if mappingType is not None:
         collisionmodel.createObject(mappingType)
 
-
     return collisionmodel
-    
+
 
 def createScene(rootNode):
     from stlib.scene import MainHeader

--- a/python/stlib/physics/mixedmaterial/rigidification.py
+++ b/python/stlib/physics/mixedmaterial/rigidification.py
@@ -84,8 +84,6 @@ def Rigidify(targetObject, sourceObject, frameOrientation, groupIndices, framePo
                 center = poscenter + list(orientation)
                 rigids.append(center)
 
-                print(rigids)
-
                 selectedIndices += map(lambda x: x, groupIndices[i])
                 indicesMap += [i] * len(groupIndices[i])
 

--- a/python/stlib/physics/mixedmaterial/rigidification.py
+++ b/python/stlib/physics/mixedmaterial/rigidification.py
@@ -86,17 +86,17 @@ def Rigidify(targetObject, sourceObject, groupIndices, frames=None, name=None, f
                 selectedPoints = mfilter(groupIndices[i], allIndices, sourcePoints)
 
                 if len(frames[i]) == 3:
-                        orientation = Quat.createFromEuler(frames[i])
+                        orientation = Quat.createFromEuler(frames[i], inDegree=True)
                         poscenter = getBarycenter(selectedPoints)
                 elif len(frames[i]) == 4:
                         orientation = frames[i]
                         poscenter = getBarycenter(selectedPoints)
                 elif len(frames[i]) == 6:
-                        orientation = Quat.createFromEuler([frames[3], frames[4], frames[5]])
-                        poscenter = list(frames[0], frames[1], frames[2])
+                        orientation = Quat.createFromEuler([frames[i][3], frames[i][4], frames[i][5]], inDegree=True)
+                        poscenter = [frames[i][0], frames[i][1], frames[i][2]]
                 elif len(frames[i]) == 7:
-                        orientation = frames[i]
-                        poscenter = [frames[0], frames[1], frames[2]]
+                        orientation = [frames[i][3], frames[i][4], frames[i][5], frames[i][6]]
+                        poscenter = [frames[i][0], frames[i][1], frames[i][2]]
                 else:
                         Sofa.msg_error("Do not understand the size of a frame.")
 

--- a/python/stlib/physics/mixedmaterial/rigidification.py
+++ b/python/stlib/physics/mixedmaterial/rigidification.py
@@ -32,7 +32,7 @@ def getBarycenter(selectedPoints):
     return poscenter
 
 
-def Rigidify(targetObject, sourceObject, groupIndices, frames=None, name=None, frameOrientations=None):
+def Rigidify(targetObject, sourceObject, groupIndices, frames=None, name=None, frameOrientation=None):
         """ Transform a deformable object into a mixed one containing both rigid and deformable parts.
 
             :param targetObject: parent node where to attach the final object.
@@ -51,9 +51,9 @@ def Rigidify(targetObject, sourceObject, groupIndices, frames=None, name=None, f
             :param str name: specify the name of the Rigidified object, is none provided use the name of the SOurceObject.
         """
         # Deprecation Warning
-        if frameOrientations is not None:
+        if frameOrientation is not None:
             Sofa.msg_warning("The parameter frameOrientations of the function Rigidify is now deprecated. Please use frames instead.")
-            frames = frameOrientations
+            frames = frameOrientation
 
         if frames is None:
             frames = [[0., 0., 0.]]*len(groupIndices)

--- a/python/stlib/physics/mixedmaterial/rigidification.py
+++ b/python/stlib/physics/mixedmaterial/rigidification.py
@@ -3,7 +3,7 @@
 Templates to rigidify a deformable object.
 
 The rigidification consist in mixing in a single object rigid and deformable parts.
-The rigid and deformable parts are interacting together. 
+The rigid and deformable parts are interacting together.
 
 **Sofa Templates:**
 
@@ -15,108 +15,118 @@ stlib.physics.mixedmaterial.Rigidify
 *******************************
 .. autofunction:: Rigidify
 
-    
-Contributors: 
+
+Contributors:
         damien.marchal@univ-lille.fr
         eulalie.coevoet@inria.fr
 """
 
 
-from splib.numerics import Vec3, Quat, sdiv, RigidDof, getOrientedBoxFromTransform 
+from splib.numerics import Vec3, Quat, sdiv
 
-def Rigidify(targetObject, sourceObject, frameOrientation, groupIndices, name=None):
+
+def Rigidify(targetObject, sourceObject, frameOrientation, groupIndices, framePosition=None, name=None):
         """ Transform a deformable object into a mixed one containing both rigid and deformable parts.
-            
+
             :param targetObject: parent node where to attach the final object.
-            :param sourceObject: node containing the deformable object. The object should be following 
-                                 the ElasticMaterialObject template. 
+            :param sourceObject: node containing the deformable object. The object should be following
+                                 the ElasticMaterialObject template.
             :param list framesOrientation: array of orientations. The length of the array should be equal to the number
                                     of rigid component. The orientation are given in eulerAngles (in degree) by passing
                                     three values or using a quaternion by passing four values.
                                     [[0,10,20], [0.1,0.5,0.3,0.4]]
-            :param list indicesLists: array of array indices to rigidify. The length of the array should be equal to the number
+            :param list groupIndices: array of array indices to rigidify. The length of the array should be equal to the number
                                 of rigid component.
-            :param str name: specify the name of the Rigidified object, is none provided use the name of the SOurceObject. 
+            :param list framePosition: array of positions. The length of the array, if given, should be equal to the number
+                                    of rigid component. If no potisions are given, the position of the rigids will be
+                                    the barycenter of the region to rigidify.
+            :param str name: specify the name of the Rigidified object, is none provided use the name of the SOurceObject.
         """
-        assert len(groupIndices) == len(frameOrientation), "size mismatch." 
+        assert len(groupIndices) == len(frameOrientation), "size mismatch."
 
-        if name==None:
+        if name is None:
                 name = sourceObject.name
-                        
+
         sourceObject.init()
         ero = targetObject.createChild(name)
 
         allPositions = sourceObject.container.position
-        allIndices = map( lambda x: x[0], sourceObject.container.points )
-        
-        centers = []
-        indicesMap=[]
+        allIndices = map(lambda x: x[0], sourceObject.container.points)
+
+        rigids = []
+        indicesMap = []
+
         def mfilter(si, ai, pts):
-                tmp=[]
-                for index in ai:
-                        if index in si:
-                                tmp.append(pts[index])
-                return tmp;        
-        
-        # get all the points from the source.         
-        sourcePoints = map(Vec3, sourceObject.dofs.position) 
-        selectedIndices=[]
-        for index in range(len(groupIndices)):
-                selectedPoints = mfilter(groupIndices[index], allIndices, sourcePoints)                 
-        
-                if len(frameOrientation[index])==3:
-                        orientation = Quat.createFromEuler(frameOrientation[index])
+                tmp = []
+                for i in ai:
+                        if i in si:
+                                tmp.append(pts[i])
+                return tmp
+
+        # get all the points from the source.
+        sourcePoints = map(Vec3, sourceObject.dofs.position)
+        selectedIndices = []
+        for i in range(len(groupIndices)):
+                selectedPoints = mfilter(groupIndices[i], allIndices, sourcePoints)
+
+                if len(frameOrientation[i]) == 3:
+                        orientation = Quat.createFromEuler(frameOrientation[i])
                 else:
-                        orientation = frameOrientation[index]
-                
-                poscenter = [0.0,0.0,0.0]
-                if len(selectedPoints) != 0:
-                        poscenter = sdiv( sum(selectedPoints), float(len(selectedPoints)))                 
+                        orientation = frameOrientation[i]
+
+                if framePosition is not None:
+                    poscenter = framePosition[i]
+                else:
+                    poscenter = [0., 0., 0.]
+                    if len(selectedPoints) != 0:
+                            poscenter = sdiv(sum(selectedPoints), float(len(selectedPoints)))
+
                 center = poscenter + list(orientation)
-                centers.append(center)
-                
-                selectedIndices += map(lambda x: x, groupIndices[index])
-                indicesMap += [index] * len(groupIndices[index])
- 
-        maps = []
-        
-        otherIndices = filter(lambda x: x not in selectedIndices, allIndices)                   
-        Kd = {v:None for k,v in enumerate(allIndices)}        
-        Kd.update( {v:[0,k] for k,v in enumerate(otherIndices)} )
-        Kd.update( {v:[1,k] for k,v in enumerate(selectedIndices)} )
+                rigids.append(center)
+
+                print(rigids)
+
+                selectedIndices += map(lambda x: x, groupIndices[i])
+                indicesMap += [i] * len(groupIndices[i])
+
+        otherIndices = filter(lambda x: x not in selectedIndices, allIndices)
+        Kd = {v: None for k, v in enumerate(allIndices)}
+        Kd.update({v: [0, k] for k, v in enumerate(otherIndices)})
+        Kd.update({v: [1, k] for k, v in enumerate(selectedIndices)})
         indexPairs = [v for kv in Kd.values() for v in kv]
-        
+
         freeParticules = ero.createChild("DeformableParts")
         freeParticules.createObject("MechanicalObject", template="Vec3", name="dofs",
-                                                        position=[allPositions[i] for i in otherIndices])
-        
+                                    position=[allPositions[i] for i in otherIndices])
+
         rigidParts = ero.createChild("RigidParts")
-        rigidParts.createObject("MechanicalObject", template="Rigid3", name="dofs", reserve=len(centers), position=centers)
-           
-        rigidifiedParticules=rigidParts.createChild("RigidifiedParticules")
+        rigidParts.createObject("MechanicalObject", template="Rigid3", name="dofs", reserve=len(rigids), position=rigids)
+
+        rigidifiedParticules = rigidParts.createChild("RigidifiedParticules")
         rigidifiedParticules.createObject("MechanicalObject", template="Vec3", name="dofs",
-                                                        position=[allPositions[i] for i in selectedIndices])
+                                           position=[allPositions[i] for i in selectedIndices])
         rigidifiedParticules.createObject("RigidMapping", name="mapping", globalToLocalCoords='true', rigidIndexPerPoint=indicesMap)
 
         sourceObject.removeObject(sourceObject.solver)
         sourceObject.removeObject(sourceObject.integration)
         sourceObject.removeObject(sourceObject.LinearSolverConstraintCorrection)
 
-        ## The coupling is made with the sourceObject. If the source object is from an ElasticMaterialObject
-        ## We need to get the owning node form the current python object (this is a hack because of the not yet 
-        ## Finalized design of stlib. 
+        # The coupling is made with the sourceObject. If the source object is from an ElasticMaterialObject
+        # We need to get the owning node form the current python object (this is a hack because of the not yet
+        # Finalized design of stlib.
         coupling = sourceObject
-        if hasattr(sourceObject, "node"):      
+        if hasattr(sourceObject, "node"):
             coupling = sourceObject.node
-        
-        coupling.createObject("SubsetMultiMapping", name="mapping", template="Vec3,Vec3", 
-                                 input=freeParticules.dofs.getLinkPath()+" "+rigidifiedParticules.dofs.getLinkPath(), 
-                                 output=sourceObject.dofs.getLinkPath(), 
-                                 indexPairs=indexPairs)
-        
+
+        coupling.createObject("SubsetMultiMapping", name="mapping", template="Vec3,Vec3",
+                              input=freeParticules.dofs.getLinkPath()+" "+rigidifiedParticules.dofs.getLinkPath(),
+                              output=sourceObject.dofs.getLinkPath(),
+                              indexPairs=indexPairs)
+
         rigidifiedParticules.addChild(coupling)
         freeParticules.addChild(coupling)
         return ero
+
 
 def createScene(rootNode):
         """
@@ -125,30 +135,29 @@ def createScene(rootNode):
         from stlib.physics.deformable import ElasticMaterialObject
         from stlib.physics.mixedmaterial import Rigidify
         from splib.objectmodel import setData
-        
+
         MainHeader(rootNode, plugins=["SofaSparseSolver"])
-        rootNode.VisualStyle.displayFlags="showBehavior"
-         
-        modelNode = rootNode.createChild("Modeling")        
+        rootNode.VisualStyle.displayFlags = "showBehavior"
+
+        modelNode = rootNode.createChild("Modeling")
         elasticobject = ElasticMaterialObject(modelNode, "mesh/liver.msh", "ElasticMaterialObject")
-                
-        ## Rigidification of the elasticobject for given indices with given frameOrientations.                           
+
+        # Rigidification of the elasticobject for given indices with given frameOrientations.
         o = Rigidify(modelNode,
                      elasticobject,
-                     name="RigidifiedStructure", 
-                     frameOrientation = [[0.0,0.0,0.0], [0.0,0.0,0.0]],
-                     groupIndices=[[0,1,2,3,4,5,6,7,8,9,10], [48,49,50,51]])
+                     name="RigidifiedStructure",
+                     frameOrientation=[[0., 0., 0], [0., 0., 0]],
+                     groupIndices=[[0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10], [48, 49, 50, 51]])
 
-        ## Activate some rendering on the rigidified object. 
-        setData(o.RigidParts.dofs, showObject=True, showObjectScale=1,drawMode=2)
-        setData(o.RigidParts.RigidifiedParticules.dofs, showObject=True, showObjectScale=0.1, 
-                drawMode=1, showColor=[1.0,1.0,0.0,1.0])
+        # Activate some rendering on the rigidified object.
+        setData(o.RigidParts.dofs, showObject=True, showObjectScale=1, drawMode=2)
+        setData(o.RigidParts.RigidifiedParticules.dofs, showObject=True, showObjectScale=0.1,
+                drawMode=1, showColor=[1., 1., 0., 1.])
         setData(o.DeformableParts.dofs, showObject=True, showObjectScale=0.1, drawMode=2)
         o.RigidParts.createObject("FixedConstraint", indices=0)
-        
-        simulationNode = rootNode.createChild("Simulation")        
+
+        simulationNode = rootNode.createChild("Simulation")
         simulationNode.createObject("EulerImplicitSolver")
         simulationNode.createObject("CGLinearSolver")
-        simulationNode.addChild(o)        
+        simulationNode.addChild(o)
         return rootNode
-


### PR DESCRIPTION
The position of the rigids is currently the barycenter of the given region to rigidify. 
This PR allows the user to specify the position of the rigids himself (default is still the barycenter computation). 
Can be useful if you need to map objects on the rigids without specifying global positions. 
