### PR TITLE
Rigid object changes [BREAKING]

### DIFF
--- a/python/stlib/physics/rigid/rigidobject.py
+++ b/python/stlib/physics/rigid/rigidobject.py
@@ -16,7 +16,7 @@ def RigidObject(node, name="RigidObject",
                 noSolver=False,
                 collisionGroup=None):
     """Creates and adds rigid body from a surface mesh.
-    
+
     Args:
         surfaceMeshFileName (str):  The path or filename pointing to surface mesh file.
 

--- a/python/stlib/physics/rigid/rigidobject.py
+++ b/python/stlib/physics/rigid/rigidobject.py
@@ -16,7 +16,7 @@ def RigidObject(node, name="RigidObject",
                 noSolver=False,
                 collisionGroup=None):
     """Creates and adds rigid body from a surface mesh.
-
+    
     Args:
         surfaceMeshFileName (str):  The path or filename pointing to surface mesh file.
 


### PR DESCRIPTION
I added new parameters:

* collisionMeshFileName : we may want the visu and collision mesh to be different (not breaking: if no collisionMeshFileName is given it will use surfaceMeshFileName as before)
* noSolver : we may want to use one solver on top of the scene, to solve multiple bodies. isAStaticObject actually does that, but also deactivates the collision...
* collisionGroup : we may want to set two objects in a same collision group and I find it painful to do it afterward...

I also changed the name of the MechanicalObject. This can be massively breaking... but, I think it's good to unify the library...

I find these changes "ugly". I don't really like this idea of adding a new parameter each time we want the template to be more "adjustable", but I can't think of another way...