### PR TITLE
FIX: ElasticMaterialObject prefab creation

### DIFF
--- a/python/stlib/physics/deformable/elasticmaterialobject.py
+++ b/python/stlib/physics/deformable/elasticmaterialobject.py
@@ -25,11 +25,9 @@ class ElasticMaterialObject(SofaObject):
                  totalMass=1.0, solver=None):
 
         self.node = Node(attachedTo, name)
-        ElasticMaterialObject.createPrefab(self,
-                                           volumeMeshFileName, name, rotation, translation, scale, surfaceMeshFileName,
-                                           collisionMesh, withConstrain, surfaceColor, poissonRatio, youngModulus, totalMass, solver)
+        self.createPrefab(volumeMeshFileName, name, rotation, translation, scale, surfaceMeshFileName,
+                          collisionMesh, withConstrain, surfaceColor, poissonRatio, youngModulus, totalMass, solver)
 
-    @staticmethod
     def createPrefab(self,
                      volumeMeshFileName=None,
                      name="ElasticMaterialObject",


### PR DESCRIPTION
The createPrefab method was declared as static, but "self" was passed to it and used internally. (thus I don't see why that would be a static method...)
It was causing issues in the CableGripper tutorial (step0)

The decorator was probably here for a reason, so let me know if I misread the purpose of this code...