### PR TITLE
Fix warnings, errors, and new feature for quat

### DIFF
--- a/python3/src/splib3/numerics/__init__.py
+++ b/python3/src/splib3/numerics/__init__.py
@@ -208,7 +208,6 @@ class Transform(object):
     def __init__(self, translation, orientation=None, eulerRotation=None):
         self.translation = translation
         if eulerRotation != None:
-            print("=================================> ", eulerRotation)
             self.orientation = Quat.createFromEuler( to_radians( eulerRotation ) )
         elif orientation != None:
             self.orientation = orientation

--- a/python3/src/splib3/numerics/quat.py
+++ b/python3/src/splib3/numerics/quat.py
@@ -1,6 +1,7 @@
 import numpy
 import math
-from math import pi
+from math import pi, sqrt
+
 
 class Quat(numpy.ndarray):
     """ The Quat class implements the following:
@@ -55,7 +56,6 @@ class Quat(numpy.ndarray):
         print(cls.__new__.__doc__)
         return super(Quat,cls).__new__(cls, shape=(4,), dtype=float, buffer=numpy.array([0.,0.,0.,1.]))
 
-
     def __eq__(self, other):
         """ Quat overriding of __eq__ so that (q1==q2) returns a boolean.
         """
@@ -65,18 +65,15 @@ class Quat(numpy.ndarray):
                 return False
         return True
 
-
     def __ne__(self, other):
         """ Quat overriding of __ne__ so that (q1!=q2) returns a boolean.
         """
         return not (self == other)
 
-
     def normalize(self, *args):
         """ Function normalize of class Quat normalize the vector. The function expects no argument.
         """
         self /= self.getNorm()
-
 
     def rotateFromQuat(self, qb):
         """Function rotateFromQuat of class Quat rotates the current Quat from the given one.
@@ -92,7 +89,6 @@ class Quat(numpy.ndarray):
 
         self.put(range(4),self.product(self,qb))
 
-
     def rotateFromEuler(self, v, axes="sxyz"):
         """Function rotateFromEuler of class Quat combine the current Quat from euler angles.
 
@@ -107,13 +103,11 @@ class Quat(numpy.ndarray):
         q = Quat.createFromEuler(v)
         self.put(range(4),self.product(self,q))
 
-
     def flip(self):
         """Function flip of class Quat flips the quaternion to the real positive hemisphere if needed.
         """
         if self.getRe() < 0:
             self.put(range(4),-1*self)
-
 
     def rotate(self,v):
         """Function rotate of class Quat rotate a vector using a quaternion.
@@ -133,12 +127,10 @@ class Quat(numpy.ndarray):
 
         return numpy.array([v0,v1,v2])
 
-
     def getNorm(self):
         """ Returns the norm of the quaternion.
         """
         return numpy.linalg.norm(self)
-
 
     def getRe(self):
         """Returns the real part of the quaternion.
@@ -151,7 +143,6 @@ class Quat(numpy.ndarray):
         """
         return float(self.take(3))
 
-
     def getIm(self):
         """Returns the imaginary part of the quaternion.
 
@@ -162,7 +153,6 @@ class Quat(numpy.ndarray):
         [0.65,0.,0.]
         """
         return numpy.array(self.take(range(3)))
-
 
     def getAxisAngle(self):
         """ Returns rotation vector corresponding to unit quaternion in the form of [axis, angle]
@@ -228,7 +218,6 @@ class Quat(numpy.ndarray):
             a[0], a[2] = a[2], a[0]
         return a
 
-
     def getMatrix(self):
         """Returns the convertion of the quaternion into rotation matrix form.
         """
@@ -261,7 +250,6 @@ class Quat(numpy.ndarray):
 
         return matrix
 
-
     def getConjugate(self):
         """Returns the conjugate of the quaternion.
 
@@ -273,20 +261,26 @@ class Quat(numpy.ndarray):
         """
         return Quat(-self.take(0),-self.take(1),-self.take(2),self.take(3))
 
-
     def getInverse(self):
         """Returns the inverse of the quaternion.
 
         If you are dealing with unit quaternions, use getConjugate() instead.
         """
-        return  self.getConjugate() / self.getNorm()**2
-
+        return self.getConjugate() / self.getNorm()**2
 
     def toString(self):
         """Returns the quaternion in string format.
         """
-        return  str(self.take(0))+" "+str(self.take(1))+" "+str(self.take(2))+" "+str(self.take(3))
+        return str(self.take(0))+" "+str(self.take(1))+" "+str(self.take(2))+" "+str(self.take(3))
 
+    @staticmethod
+    def createFromVectors(v1,v2):
+        from splib3.numerics.vec3 import Vec3
+        q = Quat()
+        q[0:3] = Vec3.cross(v2, v1)
+        q[3] = sqrt((v1.getNorm() * v1.getNorm()) * (v2.getNorm() * v2.getNorm())) + Vec3.dot(v1, v2)
+        q.normalize();
+        return q
 
     @staticmethod
     def createFromAxisAngle(axis, angle):

--- a/python3/src/splib3/numerics/vec3.py
+++ b/python3/src/splib3/numerics/vec3.py
@@ -1,6 +1,7 @@
 import numpy
 import math
 
+
 class Vec3(numpy.ndarray):
     """ The Vec3 class implements the following:
 
@@ -53,7 +54,6 @@ class Vec3(numpy.ndarray):
         print(cls.__new__.__doc__)
         return super(Vec3,cls).__new__(cls, shape=(3,), dtype=float, buffer=numpy.array([args[0],args[0],args[0]]))
 
-
     def __eq__(self, other):
         """ Vec3 overriding of __eq__ so that (v1==v2) returns a boolean.
         """
@@ -63,30 +63,25 @@ class Vec3(numpy.ndarray):
                 return False
         return True
 
-
     def __ne__(self, other):
         """ Vec3 overriding of __ne__ so that (v1!=v2) returns a boolean.
         """
         return not (self == other)
-
 
     def getNorm(self):
         """ Returns the norm of the vector.
         """
         return math.sqrt(Vec3.dot(self,self))
 
-
     def toString(self):
         """ Returns the vector in string format.
         """
         return str(self.take(0))+" "+str(self.take(1))+" "+str(self.take(2))
 
-
     def toList(self):
         """ Returns the vector in list format.
         """
         return [self.take(0), self.take(1), self.take(2)]
-
 
     def normalize(self, *args):
         """ Normalize the vector.
@@ -129,7 +124,6 @@ class Vec3(numpy.ndarray):
     #   if len(args) == 1 and type(args[0]) == Quat:
     #       self.rotateFromQuat(args[0])
     #   elif ...
-
 
     def rotateFromQuat(self, q):
         """Function rotateFromQuat from the Vec3 class rotates the current vector by the rotation

--- a/python3/src/stlib3/physics/deformable/elasticmaterialobject.py
+++ b/python3/src/stlib3/physics/deformable/elasticmaterialobject.py
@@ -37,7 +37,7 @@ class ElasticMaterialObject(Sofa.Prefab):
             plugins.append('SofaImplicitOdeSolver')
             self.integration = self.addObject('EulerImplicitSolver', name='integration')
             plugins.append('SofaSparseSolver')
-            self.solver = self.addObject('SparseLDLSolver', name="solver")
+            self.solver = self.addObject('SparseLDLSolver', name="solver", template='CompressedRowSparseMatrixd')
             # Eulalie: 01/21 a bit hard to debug... when uncommented, no warning or error shows up, yet all components won't just be created...
             # self.solverName = 'solver'
 
@@ -52,7 +52,7 @@ class ElasticMaterialObject(Sofa.Prefab):
         else:
             self.loader = self.addObject('MeshVTKLoader', name='loader', filename=self.volumeMeshFileName.value, rotation=list(self.rotation.value), translation=list(self.translation.value), scale3d=list(self.scale.value))
 
-        self.container = self.addObject('TetrahedronSetTopologyContainer', src=self.loader.getLinkPath(), name='container')
+        self.container = self.addObject('TetrahedronSetTopologyContainer', position=self.loader.position.getLinkPath(), tetras=self.loader.tetras.getLinkPath(), name='container')
         self.dofs = self.addObject('MechanicalObject', template='Vec3', name='dofs')
 
         # To be properly simulated and to interact with gravity or inertia forces, an elasticobject

--- a/python3/src/stlib3/scene/scene.py
+++ b/python3/src/stlib3/scene/scene.py
@@ -66,7 +66,7 @@ def Scene(root, gravity=[0.0,-9.81,0.0],
             if iterative:
                 node.addObject('CGLinearSolver', name='LinearSolver')
             else:
-                node.addObject('SparseLDLSolver', name='LinearSolver')
+                node.addObject('SparseLDLSolver', name='LinearSolver', template='CompressedRowSparseMatrixd')
             return node
 
         def addContactHeader():

--- a/python3/src/stlib3/solver/defaultsolver.py
+++ b/python3/src/stlib3/solver/defaultsolver.py
@@ -12,7 +12,7 @@ def DefaultSolver(node, iterative=True):
     if iterative:
         return node.addObject('CGLinearSolver', name='LinearSolver')
 
-    return node.addObject('SparseLDLSolver', name='LinearSolver')
+    return node.addObject('SparseLDLSolver', name='LinearSolver', template='CompressedRowSparseMatrixd')
 
 ### This function is just an example on how to use the DefaultHeader function.
 def createScene(rootNode):


### PR DESCRIPTION
In this PR:

- adds new method `createFromVectors(v1,v2)` for quat class
- fixes `SparseLDLSolver` template warning
- fixes error messages from `TetrahedronSetTopologyContainer` in `ElasticMaterialObject` prefab. It seems that the list of edges and triangles can be inconsistent with the tetras. I propose to fix the problem by letting SOFA computing them from the given tetras.  