### PR TITLE
I removed the import of Quat which is not necessary

### DIFF
--- a/python3/src/splib3/numerics/quat.py
+++ b/python3/src/splib3/numerics/quat.py
@@ -294,7 +294,6 @@ class Quat(numpy.ndarray):
 
         Note that the angle should be in radian.
         """
-        from quat import Quat
         q = Quat()
         q[0]=axis[0]*math.sin(angle/2.)
         q[1]=axis[1]*math.sin(angle/2.)


### PR DESCRIPTION
In the quat.py file, there was an import of the Quat() class which was not necessary because we are still in the same file where the class was created.
I then removed this import in order to be able to use the method createFromAxisAngle