### PR TITLE
[stlib3.scene.scene] Dirty fix for OglFrame bug with macos

### DIFF
--- a/python3/src/stlib3/scene/scene.py
+++ b/python3/src/stlib3/scene/scene.py
@@ -1,5 +1,7 @@
 # -*- coding: utf-8 -*-
+import Sofa
 import Sofa.Core
+import platform
 from splib3.animation import AnimationManager
 
 class SofaRuntime(object):
@@ -28,7 +30,10 @@ def Settings(plugins=[], repositoryPaths=[]):
                 self.addObject('AddResourceRepository', name="AddResourceRepository"+str(i), path=repository)
                 i+=1
 
-        self.addObject('OglSceneFrame', style="Arrows", alignment="TopRight")
+        if platform.system() != "Darwin":
+            self.addObject('OglSceneFrame', style="Arrows", alignment="TopRight")
+        else:
+            Sofa.msg_warning(self, "MacOs detected, removing OglSceneFrame from the Settings because of compatibility problem.")
         self.addObject('AttachBodyButtonSetting', name="mouseButton")
 
         return self


### PR DESCRIPTION
Detect the OS to replace on macOS the OglSceneFrame with a message warning
the user it will not work.