### PR TITLE
Check if key exists in dictionary before access

### DIFF
--- a/python3/src/splib3/objectmodel/__init__.py
+++ b/python3/src/splib3/objectmodel/__init__.py
@@ -47,8 +47,9 @@ class SofaPrefab(object):
             o = self.cls(*args, **kwargs)
             frameinfo = getframeinfo(currentframe().f_back)
             o.node.addData(name="Prefab type", group="Infos", help="", type="string", value=str(o.__class__.__name__))
-            o.node.addData(name="modulepath", group="Infos", help="", type="string",
-                              value=str(os.path.dirname(os.path.abspath(sys.modules[o.__module__].__file__))))
+            if o.__module__ in sys.modules:
+                o.node.addData(name="modulepath", group="Infos", help="", type="string",
+                               value=str(os.path.dirname(os.path.abspath(sys.modules[o.__module__].__file__))))
             o.node.addData(name="Defined in", group="Infos", help="", type="string", value=str(self.definedloc))
             o.node.addData(name="Instantiated in", group="Infos", help="", type="string", value=str((frameinfo.filename, frameinfo.lineno)))
             o.node.addData(name="Help", group="Infos", help="", type="string", value=str(getdoc(o)))


### PR DESCRIPTION
The following triggers a KeyError exception because the key MazeScene is not in `sys.modules`:
https://github.com/SofaDefrost/SofaGym/blob/70f2a5b34f012f2ba071eddc0cec7e71d30841e2/sofagym/envs/Maze/MazeScene.py

This PR checks if the key is in the dictionary first.