### PR TITLE
Add sofa branch v22.12.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,7 +13,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-20.04, macos-10.15, windows-2019]
-        sofa_branch: [master]
+        sofa_branch: [master, v22.12]
 
     steps:
       - name: Setup SOFA and environment

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,7 +12,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-20.04, macos-10.15, windows-2019]
+        os: [ubuntu-20.04, macos-11, windows-2019]
         sofa_branch: [master, v22.12]
 
     steps:


### PR DESCRIPTION
I need it for v22.12 binaries, necessary for the ongoing Conda package.