### PR TITLE
Fix v23.06 ci

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -119,7 +119,7 @@ jobs:
         with:
           name: ${{ env.RELEASE_NAME }}
           tag_name: ${{ env.RELEASE_TAGNAME }}
-          fail_on_unmatched_files: true
+          fail_on_unmatched_files: false
           body: |
             Last updated on ${{ env.RELEASE_DATE }}
           files: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,7 +13,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-20.04, macos-11, windows-2019]
-        sofa_branch: [master, v22.12]
+        sofa_branch: [v23.06]
 
     steps:
       - name: Setup SOFA and environment


### PR DESCRIPTION
- Update ci.yml to run CI on the v23.06 branch (and not master)
- Temporarily disable MacOS build as it seems down