### PR TITLE
Do not stop deploy on failure.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -119,7 +119,7 @@ jobs:
         with:
           name: ${{ env.RELEASE_NAME }}
           tag_name: ${{ env.RELEASE_TAGNAME }}
-          fail_on_unmatched_files: true
+          fail_on_unmatched_files: false
           body: |
             Last updated on ${{ env.RELEASE_DATE }}
           files: |


### PR DESCRIPTION
Fix broken v22.12 release due to stopping deployment of artifacts as macOS CI is currently down. This enables to deploy v22.12 artifacts even if macOS is currently not available.