### PR TITLE
Do not stop deploy on failure.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -119,7 +119,7 @@ jobs:
         with:
           name: ${{ env.RELEASE_NAME }}
           tag_name: ${{ env.RELEASE_TAGNAME }}
-          fail_on_unmatched_files: true
+          fail_on_unmatched_files: false
           body: |
             Last updated on ${{ env.RELEASE_DATE }}
           files: |


### PR DESCRIPTION
This fix the broken *Deploy artifact* Github action as macOS CI is curretly down. This allows to deploy available artifacts for `master` (here Linux and Windows), even if one is broken. This is probably the desired behavior in general and future releases, so it might be considered to be merged in `master`. This would also making plugin CI consistent (sofa-framework/SofaPython3#364).