### PR TITLE
Remove deprecation warning that may create errors

### DIFF
--- a/python3/src/splib3/topology/remeshing.py
+++ b/python3/src/splib3/topology/remeshing.py
@@ -41,9 +41,9 @@ def index_from_axis(points,axis,old_indices = None): #
         :returns: new_points : tab of the points in the new order
         :returns: ind_tab : tab that contains [old_indices] at new indices position. Liste des anciens indices des points, triés dans le nouvel ordre
         """
-    if old_indices == 'null':
-        raise DeprecationWarning("Attention, old_indices est à 'null', the new norm is old_indices = None")
-        # old_indices = None
+    # if old_indices == 'null':
+    #     raise DeprecationWarning("Attention, old_indices est à 'null', the new norm is old_indices = None")
+    #     # old_indices = None
 
     if old_indices is None :
         old_indices = default_indices(len(points))


### PR DESCRIPTION
On my computer, these 3 lines create an error after my python update (I don't know why).

To be sure to avoid them for users, I just remove it.

What do you think ?